### PR TITLE
feat(price_analysis): save measurement

### DIFF
--- a/src/clients/firestore-access.go
+++ b/src/clients/firestore-access.go
@@ -27,7 +27,7 @@ func GetFirestoreClient() (*firestore.Client, error) {
 
 		// ::: For deployed apps ::: //
 		app, errNewApp := firebase.NewApp(ctx, nil)
-		// ::: End local apps ::: //
+		// ::: End deployed apps ::: //
 
 		if errNewApp != nil {
 			firestoreError = errNewApp

--- a/src/function.go
+++ b/src/function.go
@@ -44,8 +44,10 @@ func scrappHardware(w http.ResponseWriter, r *http.Request) {
 
 	// Scrappeamos
 	result := services.ScrapItem(itemsInTarget[0])
-
 	log.Println("resultado de la ejecución: ", result)
+
+	// Actualizamos el historico de precios
+	services.UpdateItemBulk(ctx, []services.ScrapedItem{result})
 
 	fmt.Fprintf(w, "no fuimos")
 

--- a/src/services/colly-scrapper-service.go
+++ b/src/services/colly-scrapper-service.go
@@ -11,14 +11,19 @@ import (
 	"russell.com/hardware_scrapper/structures"
 )
 
-func ScrapItem(target structures.Items_in_target) map[string]int {
+type ScrapedItem struct {
+	ItemId       string
+	ScrapResults map[string][]int
+}
+
+func ScrapItem(target structures.Items_in_target) ScrapedItem {
 	collyClient := clients.GetCollyClient()
 	targets := target.Targets
 	storeNames := maps.Keys(targets)
 
-	resultsMap := make(map[string]int)
+	resultMap := make(map[string][]int)
 	for _, store := range storeNames {
-		resultsMap[store] = 0
+		resultMap[store] = []int{0}
 	}
 
 	for i := 0; i < len(targets); i++ {
@@ -33,7 +38,7 @@ func ScrapItem(target structures.Items_in_target) map[string]int {
 			if err != nil {
 				fmt.Println("🦜 Error converting string to int:", err)
 			} else {
-				resultsMap[storeNames[i]] = intValue
+				resultMap[storeNames[i]] = []int{intValue}
 			}
 
 			// Matamos todo lo relacionado a la pagina que visitamos
@@ -45,6 +50,6 @@ func ScrapItem(target structures.Items_in_target) map[string]int {
 		collyClient.Visit(targetInfo.Url)
 	}
 
-	return resultsMap
+	return ScrapedItem{ItemId: target.Item_id, ScrapResults: resultMap}
 
 }

--- a/src/services/firestore-service.go
+++ b/src/services/firestore-service.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"russell.com/hardware_scrapper/clients"
@@ -86,38 +88,97 @@ func GetPriceAnalysis(ctx context.Context) []*firestore.DocumentSnapshot {
 	return docs
 }
 
-// =-=-==-=-=-=-=-=-=-=-=-=- METODOS UPDATE =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-type Item_update_payload struct {
-	documentRef *firestore.DocumentRef
-	Measurement int
-	itemId      string
+func GetPriceAnalysisByItemId(ctx context.Context, itemId string) (*firestore.DocumentSnapshot, error) {
+	firestoreClient, _ := clients.GetFirestoreClient()
+	docs, firestoreError := firestoreClient.Collection(constants.PRICE_ANALYSIS_COLLECTION).Where("item_id", "==", itemId).Limit(1).Documents(ctx).GetAll()
+
+	if firestoreError != nil {
+		log.Fatalf("❌ Failed getting PRICE_ANALYSIS_COLLECTION element by ID | Error: %v", firestoreError)
+	}
+
+	if len(docs) > 0 {
+		return docs[0], nil
+	} else {
+		return nil, fmt.Errorf("❌ No document found PRICE_ANALYSIS_COLLECTION with ID = %s", itemId)
+	}
 }
 
+// =-=-==-=-=-=-=-=-=-=-=-=- METODOS UPDATE =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
 // La idea es usar este metodo para hacer la actualización masiva a la colección "price_analysis".
-func UpdateItemBulk(ctx context.Context, itemsToUpdate []Item_update_payload) {
+func UpdateItemBulk(ctx context.Context, itemsToUpdate []ScrapedItem) {
 	// Obtenemos el cliente de firestore
 	firestoreClient, _ := clients.GetFirestoreClient()
 
-	// Get a new bulkWrite.
+	// Creamos el cliente para hacer actualizacion bulk
 	log.Printf("::: Creating BulkWrite client :::")
 	bulkWrite := firestoreClient.BulkWriter(ctx)
 
+	// Recorremos cada item a actualizar
 	log.Printf("::: About to update %d items :::", len(itemsToUpdate))
 	for i := 0; i < len(itemsToUpdate); i++ {
-		docRef := itemsToUpdate[i].documentRef
-		newMesurement := itemsToUpdate[i].Measurement
+		item := itemsToUpdate[i]
+		newMesurement := itemsToUpdate[i].ScrapResults
 
-		_, err := bulkWrite.Update(docRef, []firestore.Update{
-			{Path: "measurements", Value: firestore.ArrayUnion(newMesurement)},
-		})
+		// Buscamos en la BD el price_analysis relacionado
+		log.Printf("::: About to GetPriceAnalysisByItemId [%s] :::", item.ItemId)
+		priceAnalysisDoc, priceAnalysisError := GetPriceAnalysisByItemId(ctx, item.ItemId)
 
-		if err != nil {
-			// Handle any errors in an appropriate way, such as returning them.
-			log.Printf("::: An error has occurred with item %s: %s :::", itemsToUpdate[i].itemId, err)
+		// Si tiene price_analysis, actualizamos "measurements" y "last_analysis"
+		if priceAnalysisError == nil {
+			log.Printf("::: Previous price_analysis found :::")
+
+			updatedMeasurements := mergePreviousMeasurementsWithNewOnes(priceAnalysisDoc, newMesurement)
+
+			_, err := bulkWrite.Update(priceAnalysisDoc.Ref, []firestore.Update{
+				{Path: "measurements", Value: updatedMeasurements},
+				{Path: "last_analysis", Value: time.Now().UTC().Truncate(time.Second).String()},
+			})
+
+			if err != nil {
+				// Handle any errors in an appropriate way, such as returning them.
+				log.Printf("::: An error has occurred with item %s: %s :::", itemsToUpdate[i].ItemId, err)
+			}
+		} else {
+			// Si NO tiene price_analysis, creamos un doc nuevo
+			log.Printf("::: No previous price_analysis found, creating one :::")
+			documentRef := firestoreClient.Collection(constants.PRICE_ANALYSIS_COLLECTION).NewDoc()
+
+			_, err := bulkWrite.Create(documentRef, structures.Price_analysis{
+				Measurements:              newMesurement,
+				Last_analysis:             time.Now().UTC().Truncate(time.Second).String(),
+				Item_id:                   item.ItemId,
+				Analysis_interval_in_days: 7,
+			})
+
+			if err != nil {
+				// y si explota lo decimos (?)
+				log.Printf("::: An error has occurred with item %s: %s :::", itemsToUpdate[i].ItemId, err)
+			}
 		}
+
 	}
 
 	bulkWrite.Flush()
 
 	log.Printf("::: Updated measurements! ✨ :::")
+}
+
+func mergePreviousMeasurementsWithNewOnes(priceAnalysisDoc *firestore.DocumentSnapshot, newMesurement map[string][]int) map[string][]int {
+	var priceAnalysis structures.Price_analysis
+	erroMapping := priceAnalysisDoc.DataTo(&priceAnalysis)
+	if erroMapping != nil {
+		log.Fatalf("❌ Failed mapping Price_analysis | Error: %v", erroMapping)
+	}
+
+	result := priceAnalysis.Measurements
+
+	// Para cada "tienda", buscamos el historico y le agregamos el nuevo dato
+	for key := range result {
+		if newMesurement[key] != nil {
+			result[key] = append(result[key], newMesurement[key][0])
+		}
+	}
+
+	return result
 }

--- a/src/structures/database.go
+++ b/src/structures/database.go
@@ -23,11 +23,11 @@ type Scrap_targets struct {
 }
 
 type Price_analysis struct {
-	Id                        string
-	Item_id                   string
-	Analysis_interval_in_days int
-	Last_analysis             string
-	Measurements              map[string][]int
+	Id                        string           `id:"ID,omitempty"`
+	Item_id                   string           `firestore:"item_id,omitempty"`
+	Analysis_interval_in_days int              `firestore:"analysis_interval_in_days,omitempty"`
+	Last_analysis             string           `firestore:"last_analysis,omitempty"`
+	Measurements              map[string][]int `firestore:"measurements,omitempty"`
 }
 
 type Target struct {


### PR DESCRIPTION
Ya podemos guardar el historico 🎊 

por ahora es para un solo item pero confio que deberia poderse para al menos 10.

Dejo fotito de la consola de firestore, el dato de `measurements` está calculado yendo a venex. Por ahora son las 3 tablas que vi necesarias
![image](https://github.com/A-Donato/rusell-cloud-funtions/assets/27789840/f8145cb3-ef13-4329-bb4b-021ae03f59fa)


Localmente la consola tira esto
```
PS C:\Users\alexi\Documents\github\rusell-cloud-funtions\src\cmd> go run .\main.go
Serving function: "start-scrapping"
2024/06/30 12:52:09 estamos intentando transformar los items
🦜 solicitamos la pagina:  https://www.venex.com.ar/componentes-de-pc/placas-de-video/placa-de-video-gigabyte-nvisia-geforce-rtx-4080-aero-oc-16gb-gddr6x.html
🦜 obtuvimos la pagina:  https://www.venex.com.ar/componentes-de-pc/placas-de-video/placa-de-video-gigabyte-nvisia-geforce-rtx-4080-aero-oc-16gb-gddr6x.html
🦜 scraped! https://www.venex.com.ar/componentes-de-pc/placas-de-video/placa-de-video-gigabyte-nvisia-geforce-rtx-4080-aero-oc-16gb-gddr6x.html
2024/06/30 12:52:10 resultado de la ejecución:  {b8Ykw4I9CxWmvaXa7nxv map[venex:[1999999]]}
2024/06/30 12:52:10 ::: Creating BulkWrite client :::
2024/06/30 12:52:10 ::: About to update 1 items :::
2024/06/30 12:52:10 ::: About to GetPriceAnalysisByItemId [b8Ykw4I9CxWmvaXa7nxv] :::
2024/06/30 12:52:10 ::: Previous price_analysis found :::
2024/06/30 12:52:10 ::: key: venex | value: [%!s(int=1999999) %!s(int=0) %!s(int=1999999) %!s(int=0) %!s(int=0) %!s(int=0) %!s(int=0)] :::
2024/06/30 12:52:10 ::: Updated measurements! ✨ :::
```